### PR TITLE
Parse files

### DIFF
--- a/src/gist.plugin.coffee
+++ b/src/gist.plugin.coffee
@@ -12,9 +12,14 @@ module.exports = (BasePlugin) ->
                 return next()
 
             for gist in gists
-                gistScript = gist.replace(/<gist>/g,"<script src='https://gist.github.com/")
-                if gistScript.indexOf('.js') != -1
-                    gistScript = gistScript.replace(/<\/gist>/g,"'></script>")
+                gistScript = gist
+                    .replace(/<gist>/g,"<script src='https://gist.github.com/")
+                    .replace(/\.js/, '') # always trim .js
+
+                if gistScript.indexOf('?file=') != -1
+                    gistScript = gistScript
+                        .replace(/\?file=/, '.js?file=') # always append .js
+                        .replace(/<\/gist>/g,"'></script>")
                 else
                     gistScript = gistScript.replace(/<\/gist>/g,".js'></script>")
 

--- a/test/out-expected/gist.html
+++ b/test/out-expected/gist.html
@@ -7,6 +7,8 @@
 <body>
   <script src='https://gist.github.com/3788257.js'></script>
   <script src='https://gist.github.com/3431249.js'></script>
+  <script src='https://gist.github.com/3431249.js'></script>
+  <script src='https://gist.github.com/3431249.js?file=style.css'></script>
   <script src='https://gist.github.com/3431249.js?file=style.css'></script>
 </body>
 </html>

--- a/test/src/documents/gist.html
+++ b/test/src/documents/gist.html
@@ -7,6 +7,8 @@
 <body>
   <gist>3788257</gist>
   <gist>3431249</gist>
+  <gist>3431249.js</gist>
   <gist>3431249.js?file=style.css</gist>
+  <gist>3431249?file=style.css</gist>
 </body>
 </html>


### PR DESCRIPTION
I liked the format you used in the README a lot better, so I updated the plugin to allow it. The following are now all valid

```
<gist>3431249</gist>
<gist>3431249.js</gist>
<gist>3431249?file=style.css</gist>
<gist>3431249.js?file=style.css</gist>
```

I don't know why you'd ever really want to include the .js in the gist index, but as my original PR used it, I thought it best not to break that functionality.

If you merge this, you can close #6
